### PR TITLE
chore: prepare docker images for gcp deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,42 @@ The frontend will communicate with the backend at port 8000.
 To build and start both the backend and frontend in containers:
 
 ```
-docker-compose up --build
+docker compose up --build
 ```
 
 **Frontend** →``http://localhost:3000``
 
 **Backend health** → ``http://localhost:8000/api/health``
+
+### Install Docker on Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y docker.io docker-compose
+sudo systemctl enable --now docker
+```
+
+To run Docker without `sudo`, add your user to the `docker` group:
+
+```bash
+sudo usermod -aG docker $USER
+```
+Log out and back in for the group change to take effect.
+
+### Deploy on a GCP VM
+
+1. Copy `.env` and `docker-compose.yml` to the VM.
+2. Build and start the containers in detached mode:
+
+```bash
+docker compose up -d --build
+```
+
+3. Verify the services:
+
+```bash
+docker compose ps
+```
 
 # Scraping & Data Preprocessing for KnowledgeSpace Datasets
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,31 @@
 FROM python:3.12-slim
+
+# Ensure Python output is sent straight to the terminal without buffering
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    APP_ENV=production
+
 WORKDIR /app
 
-RUN pip install uv
+# Install the uv package manager without caching to keep the image small
+RUN pip install --no-cache-dir uv
 
+# Copy project dependency descriptors
 COPY pyproject.toml uv.lock .env ./
 
+# Copy the service account for Google Cloud access
 COPY backend/service-account.json ./service-account.json
 
-RUN UV_HTTP_TIMEOUT=300 uv sync
+# Install only production dependencies with a longer timeout for large packages
+RUN UV_HTTP_TIMEOUT=300 uv sync --no-dev --frozen
 
+# Copy the backend source code
 COPY backend/ ./
 
 EXPOSE 8000
 
+# Point the Google credentials to the copied service account
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/service-account.json
 
+# Run the backend API
 CMD ["uv", "run", "main.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.9'
+
 services:
   backend:
     build:
@@ -6,8 +7,12 @@ services:
       dockerfile: backend/Dockerfile
     env_file:
       - .env
+    environment:
+      - APP_ENV=production
     ports:
       - "8000:8000"
+    restart: always
+
   frontend:
     build:
       context: ./frontend
@@ -15,6 +20,9 @@ services:
     depends_on:
       - backend
     environment:
+      - NODE_ENV=production
       - API_URL=http://backend:8000
     ports:
       - "3000:80"
+    restart: always
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,21 @@
-FROM node:22-alpine AS frontend
+FROM node:22-alpine AS build
 WORKDIR /app
 
+# Set the environment to production inside the container
+ENV NODE_ENV=production
+
+# Install only production dependencies
 COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
 
-RUN npm ci
-
+# Copy source code and build the frontend
 COPY . ./
-
 RUN npm run build
 
+# Serve the built assets with nginx
 FROM nginx:alpine
 
-
-COPY --from=frontend /app/dist /usr/share/nginx/html
-
+COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80


### PR DESCRIPTION
## Summary
- optimize backend Dockerfile for production and GCP
- refine frontend Dockerfile for production build
- add restart policies and production env vars to compose
- document Docker installation and deployment steps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2bc86cc4832f984643fe9f1cb167